### PR TITLE
Updated control.lua

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -202,6 +202,7 @@ local function on_built(entity)
     if entity.name == "entity-ghost" or entity.type == "entity-ghost" then
         update_ghost_level(entity)
     end
+    if not entity.valid then return end
     if entity.type == "roboport" then
         update_roboport_level(entity)
     end


### PR DESCRIPTION
Added a validity check on entity variable on line 205 to prevent from crashing in certain circumstances, of which I am not entirely sure. Most probably the fact that I was trying to place a roboport on a space platform (Space Exploration + place roboports in empty space) which was halfway constructed. Note that the roboport may not be upgraded according to new technologies when that occurs, but then you get to continue playing. You can destroy and recreate the roboport (if the problem does not reoccur) to ensure that new technologies have an impact.